### PR TITLE
Define PANDOC_WRITER_OPTIONS for pandoc 3+ compatibility.

### DIFF
--- a/djot-writer.lua
+++ b/djot-writer.lua
@@ -438,6 +438,7 @@ Inlines.Note = function(el)
 end
 
 function Writer (doc, opts)
+  PANDOC_WRITER_OPTIONS = opts
   local d = blocks(doc.blocks, blankline)
   local notes = {}
   for i=1,#footnotes do


### PR DESCRIPTION
Hi,
Very small change that fixes the writer for Pandoc 3.0 and above.
Cheers