### PR TITLE
Allow comment end with attribute end.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/djot-*.rockspec

--- a/djot/attributes.lua
+++ b/djot/attributes.lua
@@ -76,8 +76,11 @@ handlers[SCANNING] = function(self, pos)
 end
 
 handlers[SCANNING_COMMENT] = function(self, pos)
-  if sub(self.subject, pos, pos) == "%" then
+  local c = sub(self.subject, pos, pos)
+  if c == "%" then
     return SCANNING
+  elseif c == "}" then
+    return DONE
   else
     return SCANNING_COMMENT
   end

--- a/rockspec.in
+++ b/rockspec.in
@@ -21,6 +21,7 @@ dependencies = {
 }
 test_dependencies = {
    "lua >= 5.1",
+   "luaposix >= 36.2"
 }
 build = {
    type = "builtin",

--- a/test/attributes.test
+++ b/test/attributes.test
@@ -197,7 +197,8 @@ two
 ```
 
 Comments start at a `%` character
-(not in quotes) and end with another `%`.
+(not in quotes) and end with another `%` or
+the end of the attribute (`}`).
 These can be used to comment up an attribute
 list or without any real attributes.
 
@@ -205,6 +206,12 @@ list or without any real attributes.
 foo{#ident % this is a comment % .class}
 .
 <p><span class="class" id="ident">foo</span></p>
+```
+
+```
+foo{#ident % this is a comment}
+.
+<p><span id="ident">foo</span></p>
 ```
 
 In block-level comment, subsequent lines must


### PR DESCRIPTION
This is a djot.lua counterpart of https://github.com/jgm/djot.js/pull/59.
I also added luaposix to the LuaRocks test dependencies.