### PR TITLE
Fix autolink rendering in djot-reader.lua

### DIFF
--- a/djot-reader.lua
+++ b/djot-reader.lua
@@ -338,6 +338,9 @@ function Renderer:link(node)
                      title, to_attr(attrs))
 end
 
+Renderer.url = Renderer.link
+Renderer.email = Renderer.link
+
 function Renderer:image(node)
   local attrs = {}
   local dest = node.destination


### PR DESCRIPTION
The pandoc reader had no handlers for `url` and `email` AST nodes emitted by the parser for autolinks (`<https://example.com>` / `<foo@example.com>`), so any document containing one aborted with "attempt to call a nil value".

Both nodes carry `.destination` and string-content children — the exact shape `Renderer:link` already consumes — so aliasing is sufficient. Closes #21.

I didn't see a natural place to fit a test for this. The following would work, but feels a bit weird:
```diff
diff --git a/Makefile b/Makefile
index 727ee79..f0aef94 100644
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ ci: testall install
        pandoc -t djot-writer.lua m.txt -o m.dj
        pandoc -f djot-reader.lua m.dj -o m.html
        rm m.dj m.html
+       printf 'See <https://example.com> and <foo@example.com>.\n' \
+         | pandoc -f djot-reader.lua -t html > autolinks.html
+       grep -q 'href="https://example.com"' autolinks.html
+       grep -q 'href="mailto:foo@example.com"' autolinks.html
+       rm autolinks.html
 .PHONY: ci
 
 fuzz:
```