### PR TITLE
CI: work around LuaJIT manifest size limit on luajit jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,17 @@ jobs:
       with:
         pandoc-version: '2.19.2'
     - name: Install luaposix for fuzz test
+      # The full luarocks.org manifest exceeds LuaJIT's 65536-constants-per-
+      # function bytecode limit, so on luajit we install via per-maintainer
+      # manifests, which are small enough to load. luaposix is gvvaughan's;
+      # its bit32 dep (Lua 5.1 / LuaJIT only) is siffiejoe's.
       run: |
-          luarocks install luaposix # for fuzz tests
+          if [ "${{ matrix.luaVersion }}" = "luajit" ]; then
+            luarocks install --only-server=https://luarocks.org/manifests/siffiejoe bit32
+            luarocks install --only-server=https://luarocks.org/manifests/gvvaughan luaposix
+          else
+            luarocks install luaposix
+          fi
     - name: Build and test
       run: |
           make ci
@@ -70,8 +79,14 @@ jobs:
     - uses: leafo/gh-actions-luarocks@v5
     - uses: mymindstorm/setup-emsdk@v14
     - name: Install luaposix for fuzz test
+      # See note in the linux job — bypass the oversized full manifest.
       run: |
-          luarocks install luaposix # for fuzz tests
+          if [ "${{ matrix.luaVersion }}" = "luajit" ]; then
+            luarocks install --only-server=https://luarocks.org/manifests/siffiejoe bit32
+            luarocks install --only-server=https://luarocks.org/manifests/gvvaughan luaposix
+          else
+            luarocks install luaposix
+          fi
     - name: Build and test
       run: |
           make ci


### PR DESCRIPTION
The full https://luarocks.org manifest now exceeds LuaJIT's 65536-constants-per-function bytecode limit, so `luarocks install luaposix` aborts with "main function has more than 65536 constants" on both the linux (luajit) and macos (luajit) jobs. Lua 5.1-5.4 are unaffected.

For the luajit matrix entry only, install via per-maintainer manifests, which are small enough to load: bit32 (luaposix's Lua 5.1 / LuaJIT dep) from siffiejoe and luaposix from gvvaughan. Other Lua versions keep the original install.